### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 opencv-python
 numpy
-Pillow
+Pillow==10.4.0
 yt-dlp


### PR DESCRIPTION
Downgraded Pillow from 12.x to 10.4.0 to fix JPEG encoding issues and ensure compatibility with Ubuntu and Mac system libraries.